### PR TITLE
Allow types not handled by Convert.ChangeType

### DIFF
--- a/ConfigInjector/ConfigurationSetting.cs
+++ b/ConfigInjector/ConfigurationSetting.cs
@@ -25,6 +25,11 @@ namespace ConfigInjector
             }
         }
 
+        protected virtual T ConvertStringValue(string settingValueString)
+        {
+            return (T) Convert.ChangeType(settingValueString, typeof (T));
+        }
+
         protected virtual IEnumerable<string> ValidationErrors(T value)
         {
             yield break;
@@ -38,6 +43,11 @@ namespace ConfigInjector
             {
                 throw new ConfigurationSettingValidationException(validationErrors);
             }
+        }
+
+        void IConfigurationSetting.SetValueFromString(string settingValueString)
+        {
+            Value = ConvertStringValue(settingValueString);
         }
 
         public static implicit operator T(ConfigurationSetting<T> setting)

--- a/ConfigInjector/IConfigurationSetting.cs
+++ b/ConfigInjector/IConfigurationSetting.cs
@@ -2,5 +2,6 @@
 {
     public interface IConfigurationSetting
     {
+        void SetValueFromString(string settingValueString);
     }
 }

--- a/ConfigInjector/SettingsRegistrationService.cs
+++ b/ConfigInjector/SettingsRegistrationService.cs
@@ -59,13 +59,10 @@ namespace ConfigInjector
 
             if (settingValueString == null) throw new InvalidOperationException("Setting {0} was not found in [web|app].config".FormatWith(settingKey));
 
-            var settingType = type.GetProperty("Value").PropertyType;
-            var settingValue = (dynamic) Convert.ChangeType(settingValueString, settingType);
+            var setting = (IConfigurationSetting)Activator.CreateInstance(type);
+            setting.SetValueFromString(settingValueString);
 
-            var setting = Activator.CreateInstance(type);
-            ((dynamic) setting).Value = settingValue;
-
-            return (IConfigurationSetting) setting;
+            return setting;
         }
 
         private void AssertThatNoAdditionalSettingsExist()


### PR DESCRIPTION
I discovered that I couldn't use a `System.TimeSpan` as a setting type.  I needed a bunch of them in the settings for my current application so I made this change to make it possible.  Now to create a `TimeSpan` setting all I need to do is:

```
public abstract class TimeSpanConfigurationSetting : ConfigurationSetting<TimeSpan>
{
    protected override TimeSpan ConvertStringValue(string settingValueString)
    {
        return TimeSpan.Parse(settingValueString);
    }
}
```

I'm not 100% happy with this solution as it probably shouldn't be the responsibility of the setting to read the string, but it was the quickest to implement non-nasty solution I could come up with.  

I think a better solution would be to be able to specify a chain of converters using the `ConfigurationConfigurator`.  Let me know what you think and if you'd rather it was done that way you could change it or wait for me to get around to it when I have some more free time :)
