### PR TITLE
Config ToString() now returns the wrapped value's ToString() regardless of type

### DIFF
--- a/ConfigInjector/ConfigurationSetting.cs
+++ b/ConfigInjector/ConfigurationSetting.cs
@@ -47,7 +47,7 @@ namespace ConfigInjector
 
         public override string ToString()
         {
-            return _value as string ?? base.ToString();
+            return "" + Value;
         }
     }
 }


### PR DESCRIPTION
Seems to make more sense to me. If it's null, it should be an empty string. Ints should just work, etc.

Why? Cause I did 
@(MvcApplication.Setting<EnvironmentColorSetting>())
