### PR TITLE
Adds documentation in readme.md for currently undocumented feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,3 +162,13 @@ Each of your parsers should implement the IValueParser interface:
             return Enum.Parse(settingValueType, settingValueString);
         }
     }
+
+## How can I exclude certain settings that are causing an ExtraneousSettingsException?
+
+Some external packages add configuration that your application doesn't care about, such as Microsoft.AspNet.Mvc.  These will cause an ExtraneousSettingsException initially since you have not created classes for them.  If you do not want to create classes for them since you will not be using them, while running up the Configurator, just call "ExcludeSettingKeys" passing in the string array of keys to ignore.  E.g:
+
+    ConfigurationConfigurator.RegisterConfigurationSettings()
+                             .FromAssemblies(/* TODO: Provide a list of assemblies to scan for configuration settings here  */)
+                             .RegisterWithContainer(configSetting => /* TODO: Register this instance with your container here */ )
+                             .ExcludeSettingKeys(new[] { "ExampleSettingKey1", "webpages:Version", "webpages:Enabled" })
+                             .DoYourThing();


### PR DESCRIPTION
When I ran up ConfigInjector in an existing MVC4 app, it threw exceptions like "ExtraneousSettingsException: Setting webpages:Version appears in [web|app].config but has no corresponding ConfigurationSetting type".

I don't care to create classes for those settings, so I wanted to ignore them.  I could not see the feature to ignore documented so I browsed the source and quickly found it was there.

This pull request is just to include a new FAQ to help others that experience the same issue as I did.  I hope the language is appropriate and consistent with the rest of the documentation.
