### PR TITLE
Added ITypeProvider support

### DIFF
--- a/ConfigInjector.UnitTests/WhenReadingTheValueForASettingThatDoesNotExist.cs
+++ b/ConfigInjector.UnitTests/WhenReadingTheValueForASettingThatDoesNotExist.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using ConfigInjector.Exceptions;
 using ConfigInjector.SettingsConventions;
+using ConfigInjector.TypeProviders;
 using NUnit.Framework;
 
 namespace ConfigInjector.UnitTests
@@ -15,7 +16,7 @@ namespace ConfigInjector.UnitTests
 
             var settingsReader = new EmptySettingsReader();
 
-            return new SettingsRegistrationService(assemblies,
+            return new SettingsRegistrationService(new AssemblyScanningTypeProvider(assemblies),
                                                    setting => { },
                                                    true,
                                                    new SettingValueConverter(),

--- a/ConfigInjector.UnitTests/WhenThereAreSettingsThatExistInWebConfigButAreNotAccountedFor.cs
+++ b/ConfigInjector.UnitTests/WhenThereAreSettingsThatExistInWebConfigButAreNotAccountedFor.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using ConfigInjector.Exceptions;
 using ConfigInjector.SettingsConventions;
+using ConfigInjector.TypeProviders;
 using NUnit.Framework;
 
 namespace ConfigInjector.UnitTests
@@ -15,7 +16,7 @@ namespace ConfigInjector.UnitTests
 
             var settingsReader = new ExtraneousSettingsReader();
 
-            return new SettingsRegistrationService(assemblies,
+            return new SettingsRegistrationService(new AssemblyScanningTypeProvider(assemblies),
                                                    setting => { },
                                                    false,
                                                    new SettingValueConverter(),

--- a/ConfigInjector.UnitTests/WhenThereAreSettingsThatHaveAmbiguousMatchesInWebConfig.cs
+++ b/ConfigInjector.UnitTests/WhenThereAreSettingsThatHaveAmbiguousMatchesInWebConfig.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using ConfigInjector.Exceptions;
 using ConfigInjector.SettingsConventions;
+using ConfigInjector.TypeProviders;
 using NUnit.Framework;
 
 namespace ConfigInjector.UnitTests
@@ -15,7 +16,7 @@ namespace ConfigInjector.UnitTests
 
             var settingsReader = new AmbiguousSettingsReader();
 
-            return new SettingsRegistrationService(assemblies,
+            return new SettingsRegistrationService(new AssemblyScanningTypeProvider(assemblies), 
                                                    setting => { },
                                                    false,
                                                    new SettingValueConverter(),

--- a/ConfigInjector/ConfigInjector.csproj
+++ b/ConfigInjector/ConfigInjector.csproj
@@ -64,6 +64,10 @@
     <Compile Include="ISettingsReader.cs" />
     <Compile Include="SettingsConventions\SettingKeyConventions.cs" />
     <Compile Include="SettingsConventions\WithSuffixSettingKeyConvention.cs" />
+    <Compile Include="TypeProviders\AssemblyScanningTypeProvider.cs" />
+    <Compile Include="TypeProviders\ExplicitTypeProvider.cs" />
+    <Compile Include="TypeProviders\FilteredAssemblyScanningTypeProvider.cs" />
+    <Compile Include="TypeProviders\ITypeProvider.cs" />
     <Compile Include="ValueParsers\YoloValueParser.cs" />
     <Compile Include="ValueParsers\EnumValueParser.cs" />
     <Compile Include="IConfigurationSetting.cs" />

--- a/ConfigInjector/Configuration/ConfigurationConfigurator.cs
+++ b/ConfigInjector/Configuration/ConfigurationConfigurator.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using ConfigInjector.TypeProviders;
 
 namespace ConfigInjector.Configuration
 {
@@ -15,7 +16,12 @@ namespace ConfigInjector.Configuration
 
         public RegisterWithContainerConfigurationConfigurator FromAssemblies(params Assembly[] assemblies)
         {
-            return new RegisterWithContainerConfigurationConfigurator(assemblies);
+            return FromTypeProvider(new AssemblyScanningTypeProvider(assemblies));
+        }
+
+        public RegisterWithContainerConfigurationConfigurator FromTypeProvider(ITypeProvider typeProvider)
+        {
+            return new RegisterWithContainerConfigurationConfigurator(typeProvider);
         }
     }
 }

--- a/ConfigInjector/Configuration/DoYourThingConfigurationConfigurator.cs
+++ b/ConfigInjector/Configuration/DoYourThingConfigurationConfigurator.cs
@@ -3,13 +3,14 @@ using System.Collections.Generic;
 using System.Reflection;
 using ConfigInjector.Exceptions;
 using ConfigInjector.SettingsConventions;
+using ConfigInjector.TypeProviders;
 using ConfigInjector.ValueParsers;
 
 namespace ConfigInjector.Configuration
 {
     public class DoYourThingConfigurationConfigurator
     {
-        private readonly Assembly[] _assemblies;
+        private readonly ITypeProvider _typeProvider;
         private readonly Action<IConfigurationSetting> _registerAsSingleton;
 
         private bool _allowConfigurationEntriesThatDoNotHaveSettingsClasses;
@@ -19,9 +20,9 @@ namespace ConfigInjector.Configuration
         private readonly List<ISettingKeyConvention> _settingKeyConventions = new List<ISettingKeyConvention>();
         private readonly List<string> _excludedKeys = new List<string>();
 
-        internal DoYourThingConfigurationConfigurator(Assembly[] assemblies, Action<IConfigurationSetting> registerAsSingleton)
+        internal DoYourThingConfigurationConfigurator(ITypeProvider typeProvider, Action<IConfigurationSetting> registerAsSingleton)
         {
-            _assemblies = assemblies;
+            _typeProvider = typeProvider;
             _registerAsSingleton = registerAsSingleton;
 
             _settingKeyConventions.AddRange(SettingKeyConventions.BuiltInConventions);
@@ -68,13 +69,13 @@ namespace ConfigInjector.Configuration
 
         public void DoYourThing()
         {
-            if (_assemblies == null) throw new ConfigurationException("You must specify the assemblies to scan for configuration settings.");
+            if (_typeProvider == null) throw new ConfigurationException("You must specify a type provider used to scan for configuration settings.");
             if (_registerAsSingleton == null) throw new ConfigurationException("You must provide a registration action.");
 
             var settingsReader = _settingsReader ?? new AppSettingsReader(_excludedKeys.ToArray());
             var settingValueConverter = new SettingValueConverter(_customValueParsers.ToArray());
 
-            var appConfigConfigurationProvider = new SettingsRegistrationService(_assemblies,
+            var appConfigConfigurationProvider = new SettingsRegistrationService(_typeProvider,
                                                                                  _registerAsSingleton,
                                                                                  _allowConfigurationEntriesThatDoNotHaveSettingsClasses,
                                                                                  settingValueConverter,

--- a/ConfigInjector/Configuration/RegisterWithContainerConfigurationConfigurator.cs
+++ b/ConfigInjector/Configuration/RegisterWithContainerConfigurationConfigurator.cs
@@ -1,20 +1,21 @@
 ﻿using System;
 using System.Reflection;
+using ConfigInjector.TypeProviders;
 
 namespace ConfigInjector.Configuration
 {
     public class RegisterWithContainerConfigurationConfigurator
     {
-        private readonly Assembly[] _assemblies;
+        private readonly ITypeProvider _typeProvider;
 
-        internal RegisterWithContainerConfigurationConfigurator(Assembly[] assemblies)
+        internal RegisterWithContainerConfigurationConfigurator(ITypeProvider typeProvider)
         {
-            _assemblies = assemblies;
+            _typeProvider = typeProvider;
         }
 
         public DoYourThingConfigurationConfigurator RegisterWithContainer(Action<IConfigurationSetting> registerAsSingleton)
         {
-            return new DoYourThingConfigurationConfigurator(_assemblies, registerAsSingleton);
+            return new DoYourThingConfigurationConfigurator(_typeProvider, registerAsSingleton);
         }
     }
 }

--- a/ConfigInjector/SettingsRegistrationService.cs
+++ b/ConfigInjector/SettingsRegistrationService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using ConfigInjector.Exceptions;
 using ConfigInjector.SettingsConventions;
+using ConfigInjector.TypeProviders;
 using ThirdDrawer.Extensions;
 using ThirdDrawer.Extensions.CollectionExtensionMethods;
 
@@ -14,7 +15,7 @@ namespace ConfigInjector
     /// </summary>
     internal class SettingsRegistrationService
     {
-        private readonly Assembly[] _assemblies;
+        private readonly ITypeProvider _typeProvider;
         private readonly Action<IConfigurationSetting> _registerAsSingleton;
         private readonly bool _allowEntriesInWebConfigThatDoNotHaveSettingsClasses;
         private readonly SettingValueConverter _settingValueConverter;
@@ -23,14 +24,14 @@ namespace ConfigInjector
 
         private IConfigurationSetting[] _stronglyTypedSettings;
 
-        public SettingsRegistrationService(Assembly[] assemblies,
+        public SettingsRegistrationService(ITypeProvider typeProvider,
                                            Action<IConfigurationSetting> registerAsSingleton,
                                            bool allowEntriesInWebConfigThatDoNotHaveSettingsClasses,
                                            SettingValueConverter settingValueConverter,
                                            ISettingsReader settingsReader,
                                            ISettingKeyConvention[] settingKeyConventions)
         {
-            _assemblies = assemblies;
+            _typeProvider = typeProvider;
             _registerAsSingleton = registerAsSingleton;
             _allowEntriesInWebConfigThatDoNotHaveSettingsClasses = allowEntriesInWebConfigThatDoNotHaveSettingsClasses;
             _settingValueConverter = settingValueConverter;
@@ -55,8 +56,7 @@ namespace ConfigInjector
 
         private IConfigurationSetting[] LoadConfigurationSettings()
         {
-            var configurationSettings = _assemblies
-                .SelectMany(a => a.GetExportedTypes())
+            var configurationSettings = _typeProvider.Get()
                 .Where(t => !t.IsInterface)
                 .Where(t => !t.IsAbstract)
                 .Where(t => typeof (IConfigurationSetting).IsAssignableFrom(t))

--- a/ConfigInjector/TypeProviders/AssemblyScanningTypeProvider.cs
+++ b/ConfigInjector/TypeProviders/AssemblyScanningTypeProvider.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace ConfigInjector.TypeProviders
+{
+    public class AssemblyScanningTypeProvider : ITypeProvider
+    {
+        private readonly Assembly[] _assemblies;
+
+        public AssemblyScanningTypeProvider(params Assembly[] assemblies)
+        {
+            _assemblies = assemblies;
+        }
+
+        public IEnumerable<Type> Get()
+        {
+            return _assemblies
+                .SelectMany(a => a.GetExportedTypes());
+        }
+    }
+}

--- a/ConfigInjector/TypeProviders/ExplicitTypeProvider.cs
+++ b/ConfigInjector/TypeProviders/ExplicitTypeProvider.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+
+namespace ConfigInjector.TypeProviders
+{
+    public class ExplicitTypeProvider : ITypeProvider
+    {
+        private readonly Type[] _types;
+
+        public ExplicitTypeProvider(Type[] types)
+        {
+            _types = types;
+        }
+
+        public IEnumerable<Type> Get()
+        {
+            return _types;
+        }
+    }
+}

--- a/ConfigInjector/TypeProviders/FilteredAssemblyScanningTypeProvider.cs
+++ b/ConfigInjector/TypeProviders/FilteredAssemblyScanningTypeProvider.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace ConfigInjector.TypeProviders
+{
+    public class FilteredAssemblyScanningTypeProvider : ITypeProvider
+    {
+        private readonly Func<Type, bool> _filter;
+        private readonly Assembly[] _assemblies;
+
+        public FilteredAssemblyScanningTypeProvider(Func<Type, bool> filter, params Assembly[] assemblies)
+        {
+            _filter = filter;
+            _assemblies = assemblies;
+        }
+
+        public IEnumerable<Type> Get()
+        {
+            return _assemblies
+                .SelectMany(a => a.GetExportedTypes())
+                .Where(_filter);
+        }
+    }
+}

--- a/ConfigInjector/TypeProviders/ITypeProvider.cs
+++ b/ConfigInjector/TypeProviders/ITypeProvider.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ConfigInjector.TypeProviders
+{
+    public interface ITypeProvider
+    {
+        IEnumerable<Type> Get();
+    }
+}


### PR DESCRIPTION
Depending on the startup options of my app, some of the config items are not mandatory. However ConfigInjector only has the option to load all config setting types in the supplied assemblies. This change allows  the developer to specify a type provider instead to customise that behaviour.
